### PR TITLE
Potential fix for code scanning alert no. 146: Resolving XML external entity in user-controlled data

### DIFF
--- a/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
+++ b/ambari-server/src/main/java/org/apache/ambari/server/state/repository/VersionDefinitionXml.java
@@ -583,6 +583,17 @@ public class VersionDefinitionXml {
   private static VersionDefinitionXml load(InputStream stream) throws Exception {
 
     XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+    // Harden the XMLInputFactory against XXE
+    try {
+      xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+    } catch (IllegalArgumentException ignored) {
+      // Property not supported by this implementation; ignore.
+    }
+    try {
+      xmlFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", Boolean.FALSE);
+    } catch (IllegalArgumentException ignored) {
+      // Property not supported by this implementation; ignore.
+    }
     XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(stream);
 
     xmlReader.nextTag();
@@ -602,6 +613,22 @@ public class VersionDefinitionXml {
     Unmarshaller unmarshaller = ctx.createUnmarshaller();
 
     SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    // Harden the SchemaFactory against XXE and external resource loading
+    try {
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    } catch (Exception ignored) {
+      // Feature not supported; ignore.
+    }
+    try {
+      factory.setProperty("http://apache.org/xml/properties/accessExternalDTD", "");
+    } catch (IllegalArgumentException ignored) {
+      // Property not supported by this implementation; ignore.
+    }
+    try {
+      factory.setProperty("http://apache.org/xml/properties/accessExternalSchema", "");
+    } catch (IllegalArgumentException ignored) {
+      // Property not supported by this implementation; ignore.
+    }
     Schema schema = factory.newSchema(new StreamSource(xsdStream));
     unmarshaller.setSchema(schema);
 


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/ambari/security/code-scanning/146](https://github.com/AndresMaqueo/ambari/security/code-scanning/146)

In general, to fix XXE vulnerabilities in Java code that uses JAXP/StAX/JAXB, you must configure the XML parser to disallow DTDs and external entities before parsing any untrusted XML. For `XMLInputFactory`/`XMLStreamReader`, this means turning off DTD support and entity resolution features. For `SchemaFactory`, you should also enable the JAXP secure processing feature and, where possible, disable access to external DTDs and schemas.

For this specific issue, the best fix with minimal functional change is to harden the `XMLInputFactory` instance created in `VersionDefinitionXml.load(InputStream stream)` and to harden the `SchemaFactory` used for XSD validation. We should set the standard and implementation-specific properties recommended by OWASP:

- On `XMLInputFactory`:
  - Disable DTD support: `XMLInputFactory.SUPPORT_DTD` → `false`
  - Disable external entities: `"javax.xml.stream.isSupportingExternalEntities"` → `false`
  - Optionally, enable namespace awareness (already default in many impls, but harmless).

- On `SchemaFactory`:
  - Enable secure processing: `XMLConstants.FEATURE_SECURE_PROCESSING` → `true`
  - Disable external DTD and schema access (if supported by the JAXP implementation) via `setProperty`:
    - `"http://apache.org/xml/properties/accessExternalDTD"` → `""`
    - `"http://apache.org/xml/properties/accessExternalSchema"` → `""`

These changes only affect how XML is parsed and validated; they do not change the higher-level behavior of reading version definition files, except that malicious XML relying on DTDs or external entities will now fail to parse. No changes are required in `URLRedirectProvider` or `VersionDefinitionResourceProvider`; they continue to pass strings/streams as before, but the parser is now safe.

Concretely, in `VersionDefinitionXml.load(InputStream stream)`, after creating `xmlFactory`, configure its anti-XXE properties before creating the `XMLStreamReader`. Also, after creating the `SchemaFactory`, configure secure processing and disable external access before creating the `Schema`. We can keep all imports (no new ones are needed, since we already import `XMLConstants`, `XMLInputFactory`, and `SchemaFactory`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in XML parsing operations by restricting unnecessary external resource access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->